### PR TITLE
reenabled whitenoise as file system option for demo

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -24,13 +24,14 @@ DATABASE_URL=sqlite:///db.sqlite3
 # DATABASE_URL=postgres://USER:PASSWORD@HOST:PORT/DBNAME
 
 # Static files
-## Parameters for using S3 as a backend for both static files and user-uploaded files.
-## Use 'localstack start' in your development environment to mock AWS S3 locally.
-## Not using S3 will make the static and user uploaded files to only work when
-## DEBUG = True. When not in debug mode, Django will not serve those files locally
-## so it needs a remote storage system.
-## Whitenoise works for serving static files locally, but not for user-uploaded files.
-USE_S3_FOR_FILE_STORAGE=False
+#
+# Choose s3, whitenoise or leave empty for default (filesystem)
+# filesystem: serves static files and uploaded media, but only via manage.py runserver [--insecure]
+# whitenoise: serves static files, even under gunicorn; but, won't serve uploaded media
+# s3: serves both but requires integration with AWS S3
+# DEFAULT_FILE_STORAGE=
+#
+# For S3:
 AWS_S3_REGION_NAME=us-west-2
 AWS_STORAGE_BUCKET_NAME=dssgsolve
 # Optional parameters

--- a/requirement/production.txt
+++ b/requirement/production.txt
@@ -6,6 +6,7 @@ rules==1.3.0
 Pillow==5.1.0
 dj-database-url==0.4.2
 gunicorn==19.7.1
+whitenoise==3.3.1
 django-markdown-deux==1.0.5
 psycopg2==2.7.5
 django-storages==1.6.6


### PR DESCRIPTION
Until we have S3 storage set up for production, (and as a shim for testing the container locally)....