### PR TITLE
extend User.objects.create_superuser()

### DIFF
--- a/src/dssgmkt/management/commands/create_superuser_cli.py
+++ b/src/dssgmkt/management/commands/create_superuser_cli.py
@@ -1,9 +1,10 @@
 from django.contrib.auth.management.commands import createsuperuser
 from django.core.management import CommandError
-from dssgmkt.models.user import UserType
+
 
 class Command(createsuperuser.Command):
-    help = 'Crate a superuser, and allow password to be provided'
+
+    help = 'Create a superuser, and allow password to be provided'
 
     def add_arguments(self, parser):
         super(Command, self).add_arguments(parser)
@@ -25,5 +26,4 @@ class Command(createsuperuser.Command):
         if password:
             user = self.UserModel._default_manager.db_manager(database).get(username=username)
             user.set_password(password)
-            user.initial_type = UserType.DSSG_STAFF
             user.save()

--- a/src/dssgmkt/models/user.py
+++ b/src/dssgmkt/models/user.py
@@ -1,9 +1,18 @@
-from django.contrib.auth.models import AbstractUser
+from django.conf import settings
+from django.contrib.auth.models import (
+    AbstractUser,
+    UserManager as AuthUserManager,
+)
 from django.db import models
 
-from dssgsolve import settings
+from .common import (
+    PHONE_REGEX,
+    ReviewStatus,
+    OrgRole,
+    SkillLevel,
+    validate_image_size,
+)
 
-from .common import PHONE_REGEX, ReviewStatus, OrgRole, SkillLevel, validate_image_size
 
 class UserType():
     DSSG_STAFF = 0
@@ -17,7 +26,16 @@ class UserType():
                 (UserType.ORGANIZATION, 'Organization member'),
                 )
 
+
+class UserManager(AuthUserManager):
+
+    def create_superuser(self, *args, **kwargs):
+        kwargs.setdefault('initial_type', UserType.DSSG_STAFF)
+        return super().create_superuser(*args, **kwargs)
+
+
 class User(AbstractUser):
+
     initial_type = models.IntegerField(
         verbose_name="Initial type of user",
         help_text="Users can check their preference when they sign up to indicate they want to be volunteers or create/join organizations",
@@ -53,6 +71,8 @@ class User(AbstractUser):
         null=True,
         validators=[validate_image_size],
     )
+
+    objects = UserManager()
 
     def full_name(self):
         return self.first_name + " " + self.last_name


### PR DESCRIPTION
> extend `User.objects.create_superuser()` s.t. superusers are always DSSG Staff

this way superusers are correct even when generated with the built-in management command, `createsuperuser`