### PR TITLE
fully automated deployment

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,5 @@
 .env
+.envrc
 *.log
 *.sqlite3
 __pycache__/

--- a/.envrc.example
+++ b/.envrc.example
@@ -30,3 +30,12 @@
 #
 # export IMAGE_REPOSITORY_NAME=
 # export IMAGE_REPOSITORY_URI=XYZ.dkr.ecr.us-west-2.amazonaws.com
+
+# SSH
+#
+# In order to access the EC2 servers that make up the cluster, for
+# example for the purpose of post-deployment tasks, the default SSH
+# command may be overridden, such that it will succeed against CLI-
+# discovered public IPs.
+#
+# export ECS_SSH="ssh -i $HOME/.ssh/my-key.pem -l ec2-user"

--- a/.envrc.example
+++ b/.envrc.example
@@ -1,0 +1,32 @@
+# The following environment variables are (optionally) used in
+# management of the marketplace project.
+#
+# These may be set in the environment ad-hoc, by a shell profile, per-
+# command or, as suggested by this file, via the .envrc file supported
+# by direnv.
+
+# AWS credentials
+#
+# manage invokes in turn the aws cli, authentication for which must be
+# set in the environment, either via AWS_ACCESS_KEY_ID and
+# AWS_SECRET_ACCESS_KEY, or via AWS_PROFILE
+#
+# export AWS_PROFILE=
+
+# AWS ECS
+#
+# The Web app container is deployed to an ECS cluster service, either
+# named upon invocation of the deployment command or set in the
+# environment.
+#
+# export ECS_CLUSTER_NAME=
+# export ECS_SERVICE_NAME=
+
+# AWS ECR
+#
+# The Web app container image is built for and pushed to a Docker
+# registry (ECR), either named upon invocation of the build command or
+# set in the environment.
+#
+# export IMAGE_REPOSITORY_NAME=
+# export IMAGE_REPOSITORY_URI=XYZ.dkr.ecr.us-west-2.amazonaws.com

--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,2 @@
+[flake8]
+max-line-length = 99

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .env
+.envrc
 *.log
 *.sqlite3
 __pycache__/

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ To quickly bootstrap your development environment, having cloned the repository,
 
     ./develop
 
-A wizard will initialize a local configuration file (`.env`), and suggest set-up steps and optionally execute these, for example:
+A wizard will initialize a local application configuration file (`.env`), and suggest set-up steps and optionally execute these, for example:
 
     (install) begin
 
@@ -106,6 +106,8 @@ The image repository name and base URI may be specified every time as arguments 
 
 Some deployment commands moreover require Amazon Web Services (AWS) credentials, which must be set in the environment – either the pair, `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY`, or simply `AWS_PROFILE`.
 
+For a full accounting of environment variables relevant to deployment, consult [.envrc.example](.envrc.example).
+
 ### Push to repository
 
 The latest deployment image may be pushed to the image repository via the build sub-command `push`:
@@ -124,4 +126,16 @@ In order to push an image to the repository, you must have created an authentica
 
 ### Image promotion
 
-TODO
+To promote the latest pushed image to production, *i.e.* to deploy, invoke the build sub-command `deploy`:
+
+    manage build deploy [--static] [--migrate]
+
+Either flag `--static` or `--migrate` instructs the `deploy` command, after promoting the latest image, to **wait** for at least one Web server to start a container based on this image; and, subsequently, to instruct this container, via SSH, to execute either the `collectstatic` command, the `migrate` command, or both.
+
+(**Note**: This wait can be significant, ~ 5 minutes. Moreover, this procedure is relatively fragile, and sensitive to, *e.g.*, overlapped deployments.)
+
+Like other `build` subcommands, `deploy` may be rolled up into the `build` command:
+
+    manage build [-p/--push] [-d/--deploy]
+
+However, in this form, no deploy-specific options may be passed, (such as `--migrate`).

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ To quickly bootstrap your development environment, having cloned the repository,
 
     ./develop
 
-A wizard will initialize a local application configuration file (`.env`), and suggest set-up steps and optionally execute these, for example:
+This wizard will initialize a local application configuration file (`.env`), and suggest set-up steps and optionally execute these, for example:
 
     (install) begin
 
@@ -134,7 +134,7 @@ Either flag `--static` or `--migrate` instructs the `deploy` command, after prom
 
 (**Note**: This wait can be significant, ~ 5 minutes. Moreover, this procedure is relatively fragile, and sensitive to, *e.g.*, overlapped deployments.)
 
-Like other `build` subcommands, `deploy` may be rolled up into the `build` command:
+Like other build subcommands, `deploy` may be rolled up into the build command:
 
     manage build [-p/--push] [-d/--deploy]
 

--- a/develop
+++ b/develop
@@ -45,12 +45,20 @@ INSTALL_URL=https://raw.githubusercontent.com/dssg/install-cli/$INSTALL_VERSION/
 
 # pyenv
 
+pyenv_bin="${PYENV_ROOT:-$HOME/.pyenv}/bin"
+
 exists_pyenv() {
-  icli::check_command pyenv
+  [ -d "$pyenv_bin" ]
 }
 
 install_pyenv() {
   curl -#L https://github.com/pyenv/pyenv-installer/raw/master/bin/pyenv-installer | bash
+
+  # bootstrap for subsequent commands
+  export PATH="$pyenv_bin:$PATH"
+
+  eval "$(pyenv init -)"
+  eval "$(pyenv virtualenv-init -)"
 }
 
 require pyenv \
@@ -112,10 +120,11 @@ ECSCLI_URL=https://s3.amazonaws.com/amazon-ecs-cli/ecs-cli-linux-amd64-latest
 ECSCLI_MD5="$ECSCLI_URL.md5"
 
 exists_ecscli() {
-  icli::check_command ecs
+  [ -f $ECSCLI_PATH ]
 }
 
 install_ecscli() {
+  mkdir -p $(dirname $ECSCLI_PATH)
   curl -#L -o $ECSCLI_PATH $ECSCLI_URL
   echo "$(curl -s $ECSCLI_MD5) $ECSCLI_PATH" | md5sum -c -
 }
@@ -126,6 +135,10 @@ require ecs-cli \
   --fail-prefix="not found ($ECSCLI_PATH)"
 
 [ -x $ECSCLI_PATH ] || chmod u+x $ECSCLI_PATH
+
+icli::set_context ecs-cli
+icli::check_command ecs || icli::message "${T_FRED}ensure that $(dirname $ECSCLI_PATH) is on your PATH"
+icli::unset_context
 
 # env
 

--- a/manage.py
+++ b/manage.py
@@ -401,9 +401,8 @@ class Build(ContainerRegistryMixin, Local):
                 result = json.loads(stdout)
                 (ec2_reservation,) = result['Reservations']
                 (ec2_instance,) = ec2_reservation['Instances']
-
-                # TODO: actually migrate and/or collecstatic on this machine
                 public_ip = ec2_instance['PublicIpAddress']
+
                 ssh = local['ssh'][public_ip]
                 base_cmd = (
                     ssh['docker ps --filter name=marketplace --format "{{.Names}}"'] |

--- a/manage.py
+++ b/manage.py
@@ -148,10 +148,10 @@ class Build(Local):
         yield command[ROOT_PATH]
 
         if args.push:
-            yield from self['push'].prepare(args)
+            yield from self['push'].delegate()
 
         if args.deploy:
-            yield from self['deploy'].prepare(args, parser)
+            yield from self['deploy'].delegate()
 
     @localmethod('-l', '--login', action='store_true', help="log in to AWS ECR")
     def push(self, args):
@@ -163,8 +163,7 @@ class Build(Local):
                 '--no-include-email',
                 '--region', 'us-west-2',
             ]
-            if args.show_commands or not args.execute_commands:
-                print('>', login_command)
+            self.print_command(login_command)
             if args.execute_commands:
                 full_command = login_command()
                 (executable, *arguments) = full_command.split()
@@ -213,6 +212,8 @@ class Build(Local):
                 envvar='ECS_SERVICE_NAME',
                 description="name of the service to update",
             )
+            # Note: This override only works when command is called
+            # outright, not when delegated:
             parser.add_argument(
                 '--no-quiet',
                 action='store_true',
@@ -237,7 +238,7 @@ class Build(Local):
                 '--service', args.service,
             ]
 
-            if getattr(args, 'report', True) and stdout is not None:
+            if args.report and stdout is not None:
                 try:
                     result = json.loads(stdout)
 

--- a/manage.py
+++ b/manage.py
@@ -127,7 +127,7 @@ class Build(Local):
             yield from self['push'].prepare(args)
 
         if args.deploy:
-            yield self['deploy'].prepare(args, parser)
+            yield from self['deploy'].prepare(args, parser)
 
     @localmethod('-l', '--login', action='store_true', help="log in to AWS ECR")
     def push(self, args):
@@ -226,7 +226,7 @@ class Build(Local):
                 '--service', service,
             ]
 
-            if args.report and stdout is not None:
+            if getattr(args, 'report', True) and stdout is not None:
                 try:
                     result = json.loads(stdout)
 

--- a/requirement/console.txt
+++ b/requirement/console.txt
@@ -1,1 +1,2 @@
 argcmdr==0.5.0
+terminaltables==3.1.0

--- a/requirement/console.txt
+++ b/requirement/console.txt
@@ -1,3 +1,4 @@
 # argcmdr==0.5.0
 https://github.com/dssg/argcmdr/archive/jsl/delegation.zip
+awscli==1.15.84
 terminaltables==3.1.0

--- a/requirement/console.txt
+++ b/requirement/console.txt
@@ -1,2 +1,3 @@
-argcmdr==0.5.0
+# argcmdr==0.5.0
+https://github.com/dssg/argcmdr/archive/jsl/delegation.zip
 terminaltables==3.1.0


### PR DESCRIPTION
## Branch summary

This branch implements the build deploy sub-command – `manage build deploy` – and includes some minor clean-up of the build command.

This branch also adds a management-specific, environment-based configuration; (though I certainly could have, I wasn't sure it would make sense to mix this with the app-specific configuration file). Because the management commands only use the environmental values as defaults, and otherwise provide an obvious interface for supplying these (the CLI), this is only environmental – (it does not use a `decouple` _.env_ file) – but, having optionally installed `direnv`, and populated a _.envrc_ file from the example, you similarly get file-based configuration, anyway.

## Set-up

This probably belongs elsewhere, but I'm not really sure right now. Moreover, the folks who need this probably have already received it several times in other places (Slack). But again to be sure:

* You'll need AWS credentials, in our case for the dsapp-ddj account. _.envrc.example_ suggests you set `AWS_PROFILE`, but of course you can simply set `AWS_ACCESS_KEY_ID` and the secret.
* You'll need unencrypted access to the marketplace server PEM. I believe everyone is now set-up with Password Store.
* You should only really need to have the CLI requirements installed, *i.e.*: `pip install -r requirement/console.txt`. But, I believe everyone has used the `develop` script, which should do the trick.

NBD, right?

## Command summary

Remember to tag first (and push that tag). I haven't gotten us past `0.0.0` yet. The last was `0.0.0b10` :stuck_out_tongue: 

Check out `manage -h`, `manage build -h` and `manage build deploy -h`.

For a super-simple build deployment, *i.e.* one requiring neither schema migrations nor refreshment of static assets in S3, you can do it all in one shot, (assuming anyway that your defaults are completely set up via the environment):

    manage build --label=THE_NEW_TAG --login --push --deploy

or tersely:

    manage build --label=THE_NEW_TAG -lpd

(though `--login` is only necessary if you haven't done so recently).

If you need to pass interesting options to the deploy command -- for example, if you want to have it automatically migrate the database or refresh S3, then don't `--deploy`; rather, having run `build`, `deploy` separately, *e.g.*:

    manage build deploy [--static] [--migrate]

## TODO

~~README updates.~~

## Note

Should it come to it, I'd prefer to be the one to merge this, though certainly no big whoop either way.