### PR TITLE
domain package refactoring into Namespace (initial work)

### DIFF
--- a/src/marketplace/domain/__init__.py
+++ b/src/marketplace/domain/__init__.py
@@ -1,0 +1,8 @@
+from namespaces import Namespace
+
+from .user import UserDomain
+
+
+marketplace = MarketplaceDomain = Namespace('marketplace')
+
+MarketplaceDomain._add_(UserDomain)

--- a/src/marketplace/tests/domain/test_org.py
+++ b/src/marketplace/tests/domain/test_org.py
@@ -2,17 +2,20 @@ from django.test import TestCase
 from django.core.exceptions import PermissionDenied
 from django.contrib.auth.models import AnonymousUser
 
+from marketplace.domain import marketplace
+from marketplace.domain.user import UserService
+from marketplace.domain.org import OrganizationService
+
 from marketplace.models.common import ReviewStatus
 from marketplace.models.user import User, UserType
 from marketplace.models.org import Organization, OrganizationRole, OrganizationSocialCause, Budget, YearsInOperation, SocialCause, GeographicalScope, OrganizationMembershipRequest, OrgRole
-from marketplace.domain.user import UserService
-from marketplace.domain.org import OrganizationService
 
 from marketplace.tests.domain.common import (
     example_organization_user, example_staff_user, example_volunteer_user,
     example_organization,
     test_users_group_inclusion, test_permission_denied_operation,
 )
+
 
 class OrganizationTestCase(TestCase):
     organization_user = None
@@ -22,11 +25,11 @@ class OrganizationTestCase(TestCase):
 
     def setUp(self):
         self.organization_user = example_organization_user()
-        UserService.create_user(None, self.organization_user, 'organization', None, None)
+        marketplace.user.add_user(self.organization_user, 'organization', None)
         self.staff_user = example_staff_user()
-        UserService.create_user(None, self.staff_user, 'organization', None, None)
+        marketplace.user.add_user(self.staff_user, 'organization', None)
         self.volunteer_user = example_volunteer_user()
-        UserService.create_user(None, self.volunteer_user, 'volunteer', None, None)
+        marketplace.user.add_user(self.volunteer_user, 'volunteer', None)
 
         self.organization = example_organization()
 

--- a/src/marketplace/tests/domain/test_proj.py
+++ b/src/marketplace/tests/domain/test_proj.py
@@ -2,6 +2,11 @@ from django.test import TestCase
 from django.core.exceptions import PermissionDenied
 from django.contrib.auth.models import AnonymousUser
 
+from marketplace.domain import marketplace
+from marketplace.domain.org import OrganizationService
+from marketplace.domain.proj import ProjectService, ProjectTaskService
+from marketplace.domain.user import UserService
+
 from marketplace.models.common import ReviewStatus, SkillLevel, Score, TaskType
 from marketplace.models.proj import (
     ProjectRole, ProjRole, VolunteerApplication, ProjectScope,
@@ -9,9 +14,6 @@ from marketplace.models.proj import (
     ProjectStatus, TaskRequirementImportance, ProjectTaskRequirement,
 )
 from marketplace.models.user import SignupCodeType, SignupCode, Skill
-from marketplace.domain.user import UserService
-from marketplace.domain.org import OrganizationService
-from marketplace.domain.proj import ProjectService, ProjectTaskService
 
 from marketplace.tests.domain.common import (
     example_organization_user, example_staff_user, example_volunteer_user,
@@ -21,6 +23,7 @@ from marketplace.tests.domain.common import (
 
 
 class ProjectTestCase(TestCase):
+
     owner_user = None
     staff_user = None
     volunteer_user = None
@@ -38,34 +41,34 @@ class ProjectTestCase(TestCase):
         code.save()
 
         self.owner_user = example_organization_user()
-        UserService.create_user(None, self.owner_user, 'organization', None, None)
+        marketplace.user.add_user(self.owner_user, 'organization')
 
         self.staff_user = example_staff_user()
-        UserService.create_user(None, self.staff_user, 'organization', None, None)
+        marketplace.user.add_user(self.staff_user, 'organization')
 
         self.volunteer_user = example_volunteer_user()
         self.volunteer_user.special_code = "AUTOMATICVOLUNTEER"
-        UserService.create_user(None, self.volunteer_user, 'volunteer', None, None)
+        marketplace.user.add_user(self.volunteer_user, 'volunteer')
         UserService.create_volunteer_profile(self.volunteer_user, self.volunteer_user.id)
 
         self.volunteer_applicant_user = example_volunteer_user(username="applicant", email="applicant@email.com")
         self.volunteer_applicant_user.special_code = "AUTOMATICVOLUNTEER"
-        UserService.create_user(None, self.volunteer_applicant_user, 'volunteer', None, None)
+        marketplace.user.add_user(self.volunteer_applicant_user, 'volunteer')
         UserService.create_volunteer_profile(self.volunteer_applicant_user, self.volunteer_applicant_user.id)
 
         self.scoping_user = example_volunteer_user(username="scopinguser", email="scoping@email.com")
         self.scoping_user.special_code = "AUTOMATICVOLUNTEER"
-        UserService.create_user(None, self.scoping_user, 'volunteer', None, None)
+        marketplace.user.add_user(self.scoping_user, 'volunteer')
         UserService.create_volunteer_profile(self.scoping_user, self.scoping_user.id)
 
         self.proj_mgmt_user = example_volunteer_user(username="managementuser", email="management@email.com")
         self.proj_mgmt_user.special_code = "AUTOMATICVOLUNTEER"
-        UserService.create_user(None, self.proj_mgmt_user, 'volunteer', None, None)
+        marketplace.user.add_user(self.proj_mgmt_user, 'volunteer')
         UserService.create_volunteer_profile(self.proj_mgmt_user, self.proj_mgmt_user.id)
 
         self.qa_user = example_volunteer_user(username="qauser", email="qa@email.com")
         self.qa_user.special_code = "AUTOMATICVOLUNTEER"
-        UserService.create_user(None, self.qa_user, 'volunteer', None, None)
+        marketplace.user.add_user(self.qa_user, 'volunteer')
         UserService.create_volunteer_profile(self.qa_user, self.qa_user.id)
 
         self.organization = example_organization()

--- a/src/marketplace/tests/domain/test_user.py
+++ b/src/marketplace/tests/domain/test_user.py
@@ -1,20 +1,18 @@
-from django.test import TestCase
-from django.core.exceptions import PermissionDenied
-from django.contrib.auth.models import AnonymousUser
-
-from marketplace.models.common import ReviewStatus, SkillLevel
-from marketplace.models.user import (
-    SignupCodeType, SignupCode, User, UserType, Skill, VolunteerSkill, )
-from marketplace.domain.user import UserService
-
-from marketplace.tests.domain.common import (
-    example_organization_user, example_staff_user, example_volunteer_user,
-    example_organization, example_project,
-    test_users_group_inclusion, test_permission_denied_operation,
-)
 import datetime
 
+from django.test import TestCase
+from django.contrib.auth.models import AnonymousUser
+
+from marketplace.domain import marketplace
+from marketplace.domain.user import UserService
+
+from marketplace.models.common import SkillLevel
+from marketplace.models.user import (
+    SignupCodeType, SignupCode, User, Skill, VolunteerSkill, )
+
+
 class UserTestCase(TestCase):
+
     dssg_staff_user = None
     volunteer_user = None
 
@@ -60,7 +58,7 @@ class UserTestCase(TestCase):
         dssg_user.last_name = "Staff"
         dssg_user.special_code = "MAKEDSSG"
         dssg_user.email = "dssg@email.com"
-        UserService.create_user(None, dssg_user, 'organization', None, None)
+        marketplace.user.add_user(dssg_user, 'organization')
         self.dssg_staff_user = dssg_user
 
     def test_organization_user(self):
@@ -69,7 +67,7 @@ class UserTestCase(TestCase):
         organization_user.first_name = "Organization"
         organization_user.last_name = "User"
         organization_user.email = "org@email.com"
-        UserService.create_user(None, organization_user, 'organization', None, None)
+        marketplace.user.add_user(organization_user, 'organization')
         self.assertEqual(UserService.get_user(organization_user, organization_user.id), organization_user)
 
         self.assertFalse(UserService.user_is_dssg_staff(organization_user, organization_user))
@@ -89,7 +87,7 @@ class UserTestCase(TestCase):
         dssg_user.last_name = "Staff"
         dssg_user.special_code = "MAKEDSSG"
         dssg_user.email = "dssg@email.com"
-        UserService.create_user(None, dssg_user, 'organization', None, None)
+        marketplace.user.add_user(dssg_user, 'organization')
         self.assertEqual(UserService.get_user(dssg_user, dssg_user.id), dssg_user)
 
         self.assertTrue(UserService.user_is_dssg_staff(dssg_user, dssg_user))
@@ -108,7 +106,7 @@ class UserTestCase(TestCase):
         volunteer_user.first_name = "Volunteer"
         volunteer_user.last_name = "User"
         volunteer_user.email = "volunteer@email.com"
-        UserService.create_user(None, volunteer_user, 'volunteer', None, None)
+        marketplace.user.add_user(volunteer_user, 'volunteer')
 
         self.assertFalse(UserService.user_is_dssg_staff(volunteer_user, volunteer_user))
         self.assertFalse(UserService.user_is_organization_creator(volunteer_user))
@@ -135,7 +133,7 @@ class UserTestCase(TestCase):
         volunteer_user2.first_name = "Volunteer2"
         volunteer_user2.last_name = "User2"
         volunteer_user2.email = "volunteer2@email.com"
-        UserService.create_user(None, volunteer_user2, 'volunteer', None, None)
+        marketplace.user.add_user(volunteer_user2, 'volunteer')
         UserService.reject_volunteer_profile(self.dssg_staff_user, volunteer_user2.volunteerprofile.id)
         self.assertFalse(UserService.user_has_approved_volunteer_profile(volunteer_user2))
 
@@ -145,7 +143,7 @@ class UserTestCase(TestCase):
         volunteer_user3.last_name = "User3"
         volunteer_user3.email = "volunteer3@email.com"
         volunteer_user3.special_code = "AUTOMATICVOLUNTEER"
-        UserService.create_user(None, volunteer_user3, 'volunteer', None, None)
+        marketplace.user.add_user(volunteer_user3, 'volunteer')
         self.assertTrue(UserService.user_has_approved_volunteer_profile(volunteer_user3))
 
         self.assertEqual(set(UserService.get_all_approved_volunteer_profiles(AnonymousUser())),
@@ -158,7 +156,7 @@ class UserTestCase(TestCase):
         volunteer_user.last_name = "User3"
         volunteer_user.email = "volunteer3@email.com"
         volunteer_user.special_code = "AUTOMATICVOLUNTEER"
-        UserService.create_user(None, volunteer_user, 'volunteer', None, None)
+        marketplace.user.add_user(volunteer_user, 'volunteer')
 
         skill1 = Skill()
         skill1.area = "Area 1"
@@ -184,32 +182,40 @@ class UserTestCase(TestCase):
                          skill2.area: [{'system_skill': skill2, 'volunteer_skill': skill2_skill}]})
 
     def test_signup_codes(self):
-        volunteer_user = User()
-        volunteer_user.username = "VolUser3"
-        volunteer_user.first_name = "Volunteer3"
-        volunteer_user.last_name = "User3"
-        volunteer_user.email = "volunteer3@email.com"
-        volunteer_user.special_code = "EXPIREDCODE"
+        self.assertFalse(
+            marketplace.user.is_valid_special_signup_code(
+                'EXPIREDCODE',
+                SignupCodeType.VOLUNTEER_AUTOMATIC_ACCEPT,
+            )
+        )
 
-        self.assertFalse(UserService.has_valid_special_signup_code(volunteer_user, SignupCodeType.VOLUNTEER_AUTOMATIC_ACCEPT))
+        for special_code in (
+            'SINGLEUSECODE',
+            'singleusecode',
+            'SingleUseCode',
+        ):
+            self.assertTrue(
+                marketplace.user.is_valid_special_signup_code(
+                    special_code,
+                    SignupCodeType.VOLUNTEER_AUTOMATIC_ACCEPT,
+                )
+            )
 
-        volunteer_user.special_code = "SINGLEUSECODE"
-        self.assertTrue(UserService.has_valid_special_signup_code(volunteer_user, SignupCodeType.VOLUNTEER_AUTOMATIC_ACCEPT))
+        marketplace.user.use_signup_code('SINGLEUSECODE')
+        self.assertFalse(
+            marketplace.user.is_valid_special_signup_code(
+                'SingleUseCode',
+                SignupCodeType.VOLUNTEER_AUTOMATIC_ACCEPT,
+            )
+        )
 
-        volunteer_user.special_code = "singleusecode"
-        self.assertTrue(UserService.has_valid_special_signup_code(volunteer_user, SignupCodeType.VOLUNTEER_AUTOMATIC_ACCEPT))
-
-        volunteer_user.special_code = "SingleUseCode"
-        self.assertTrue(UserService.has_valid_special_signup_code(volunteer_user, SignupCodeType.VOLUNTEER_AUTOMATIC_ACCEPT))
-
-        UserService.use_signup_code("SINGLEUSECODE", SignupCodeType.VOLUNTEER_AUTOMATIC_ACCEPT)
-        self.assertFalse(UserService.has_valid_special_signup_code(volunteer_user, SignupCodeType.VOLUNTEER_AUTOMATIC_ACCEPT))
-
-        self.assertEqual(set(UserService.get_signup_codes_by_text("MULTIPLECODES")),
-            set([self.code_repeated_1, self.code_repeated_2]))
+        self.assertSequenceEqual(
+            marketplace.user.query_signup_codes_by_text("MULTIPLECODES").order_by('pk'),
+            (self.code_repeated_1, self.code_repeated_2),
+        )
 
 # TODO test these methods:
 # UserService.get_user_todos(request_user, user)
 # UserService.get_volunteer_leaderboards(request_user)
 # UserService.get_featured_volunteer()
-# UserService.verify_captcha(captcha_response)
+# marketplace.user.verify_captcha(captcha_response)

--- a/src/namespaces.py
+++ b/src/namespaces.py
@@ -14,6 +14,33 @@ import functools
 import typing
 
 
+# TODO: Perhaps: Namespace class API
+#
+# Similar to Enum, could treat existing interface as functional API, and
+# supply a class inheritance interface.
+#
+# (That said, this may or may not work internally the same as Enum.)
+#
+# This way, if desired, namespace declaration could take the form:
+#
+#    class User(Namespace):
+#
+#       foo = 'bar'
+#
+#       def add(name):
+#           ...
+#
+# and be equivalent to the current:
+#
+#   UserNamespace = Namespace('user')
+#
+#   UserNamespace.foo = 'bar'
+#
+#   @UserNamespace
+#   def add(name):
+#       ...
+
+
 class Namespace:
 
     def __init__(self, name: str):

--- a/src/namespaces.py
+++ b/src/namespaces.py
@@ -1,0 +1,82 @@
+"""Flexible & precise namespace declaration
+
+WARNING: This is Python. Use modules!
+
+Intended to work like modules -- on steroids.
+
+"""
+# TODO: document
+# TODO: test
+# TODO: ???
+
+import dataclasses
+import functools
+import typing
+
+
+class Namespace:
+
+    def __init__(self, name: str):
+        self.__name__ = name
+
+    def __repr__(self):
+        return f'{self.__class__.__name__}({self.__name__!r})'
+
+    def __setattr__(self, key, value):
+        if hasattr(self, key):
+            raise self.ReassignmentError(key)
+
+        super().__setattr__(key, value)
+
+    def _update_(self, *bases, **updates):
+        if len(bases) > 1:
+            raise TypeError('_update_ expected at most 1 arguments, got 2')
+
+        for source in (bases + (updates,)):
+            stream = source
+            if hasattr(source, 'keys'):
+                stream = ((key, source[key]) for key in source.keys())
+
+            for (key, value) in stream:
+                setattr(self, key, value)
+
+    def _add_(self, *named):
+        for obj in named:
+            setattr(self, obj.__name__, obj)
+
+    def _staticmethod_(self, func):
+        self._add_(func)
+        return func
+
+    def _method_(self, func):
+        nfunc = NamespaceMethod(self, func)
+        self._add_(nfunc)
+        return nfunc
+
+    def __call__(self, named):
+        self._add_(named)
+        return named
+
+    class ReassignmentError(AttributeError):
+        pass
+
+
+# NOTE: We would get NamespaceMethod "for free" if concrete namespaces were
+# (sub)classes and entities added to their class dicts; however, not sure
+# that's the most expedient.
+
+@dataclasses.dataclass(frozen=True)
+class NamespaceMethod:
+
+    __self__: Namespace
+    __func__: typing.Callable
+
+    def __post_init__(self):
+        self.__dict__.update(
+            (name, getattr(self.__func__, name))
+            for name in functools.WRAPPER_ASSIGNMENTS
+        )
+        self.__dict__.update(self.__func__.__dict__)
+
+    def __call__(self, *args, **kwargs):
+        return self.__func__(self.__self__, *args, **kwargs)


### PR DESCRIPTION
> and minor refactoring of user creation in preparation for oauth integration

The `domain` package is no small thing, so this is a partial, or initial change, rather than a complete one.

The main thing is that using a class declaration, and `staticmethod` after static method, to give a namespace to what are really just simple functions, is a complete Python anti-pattern.

This is in part why Python modules exist and work the way they do. Put your functions in a file, import that file as a module, and voila -- you have your well-namespaced functions. And, if we were starting fresh, I would likely leave it at that.

That said, there are some limitations / particularities to using modules as namespaces in that way. And so, in sympathy, and with the hope of making something more flexible and more precise, which achieves the same without the specific and (in Python) here unnecessary language feature of the static class method, I put together a basic namespacing library, and began to apply it to the user domain module.

The main goals:

* functions are just (decorated) functions
* (and anything can be set on the namespace, not just functions)
* the namespace reflects only what you've added to it (no module imports, internals, _etc._)
* namespaces can be linked for simplicity and -- you know -- namespacing