### PR TITLE
made data migration use migration-constructed models

### DIFF
--- a/src/marketplace/migrations/0073_manual_20181001_1334.py
+++ b/src/marketplace/migrations/0073_manual_20181001_1334.py
@@ -1,23 +1,39 @@
-from django.db import migrations, models
-import django.db.models.deletion
-from marketplace.models.org import Organization, OrganizationSocialCause
-from marketplace.models.proj import Project, ProjectSocialCause
+from django.db import migrations
+
 
 def rebuild_organization_social_causes(apps, schema_editor):
-    for org in Organization.objects.all():
-        if org.main_cause and not OrganizationSocialCause.objects.filter(organization=org).exists():
-            new_social_cause = OrganizationSocialCause()
-            new_social_cause.social_cause = org.main_cause
-            new_social_cause.organization = org
-            new_social_cause.save()
+    Organization = apps.get_model('marketplace', 'Organization')
+    OrganizationSocialCause = apps.get_model('marketplace', 'OrganizationSocialCause')
+
+    organizations = (Organization.objects
+                     .exclude(main_cause='')
+                     .filter(organizationsocialcause=None))
+
+    OrganizationSocialCause.objects.bulk_create([
+        OrganizationSocialCause(
+            social_cause=organization.main_cause,
+            organization=organization,
+        )
+        for organization in organizations.iterator()
+    ])
+
 
 def rebuild_project_social_causes(apps, schema_editor):
-    for proj in Project.objects.all():
-        if proj.project_cause and not ProjectSocialCause.objects.filter(project=proj).exists():
-            new_social_cause = ProjectSocialCause()
-            new_social_cause.social_cause = proj.project_cause
-            new_social_cause.project = proj
-            new_social_cause.save()
+    Project = apps.get_model('marketplace', 'Project')
+    ProjectSocialCause = apps.get_model('marketplace', 'ProjectSocialCause')
+
+    projects = (Project.objects
+                .exclude(project_cause='')
+                .filter(projectsocialcause=None))
+
+    ProjectSocialCause.objects.bulk_create([
+        ProjectSocialCause(
+            social_cause=project.project_cause,
+            project=project,
+        )
+        for project in projects.iterator()
+    ])
+
 
 class Migration(migrations.Migration):
 


### PR DESCRIPTION
… Rather than deployed models – to avoid mid-migration incompatibilities.

*If* you're deploying only a single data migration, the models in your app *should* be appropriate for interacting with the database during your migration. But particularly in the case of deploying both schema and data migrations, you run a high risk of attempting to interact with the database using a (Python) model which reflects a *later* state of the database.

For this reason, during data migrations, vanilla models reflecting the database's *current* state are constructed and made available via the `apps` object.

[[Docs]](https://docs.djangoproject.com/en/2.1/topics/migrations/#data-migrations)