### PR TITLE
social auth (sign-up)

### DIFF
--- a/requirement/production.txt
+++ b/requirement/production.txt
@@ -1,9 +1,10 @@
 Django==2.0.9
+django-allauth==0.37.1
 django-countries==5.3.1
 django-widget-tweaks==1.4.2
 python-decouple==3.1
 rules==1.3.0
-Pillow==5.1.0
+Pillow==5.2.0
 dj-database-url==0.4.2
 gunicorn==19.7.1
 whitenoise==3.3.1

--- a/src/marketplace/apps.py
+++ b/src/marketplace/apps.py
@@ -1,6 +1,12 @@
+import importlib
+
 from django.apps import AppConfig
 
 
 class MarketplaceConfig(AppConfig):
 
     name = 'marketplace'
+    verbose_name = 'Solve for Good'
+
+    def ready(self):
+        importlib.import_module('marketplace.signals')

--- a/src/marketplace/models/user.py
+++ b/src/marketplace/models/user.py
@@ -436,6 +436,7 @@ class BadgeTier():
                 )
 
 class UserBadge(models.Model):
+
     type = models.CharField(
         max_length=2,
         choices=BadgeType.get_choices(),

--- a/src/marketplace/signals.py
+++ b/src/marketplace/signals.py
@@ -1,3 +1,4 @@
+import allauth.socialaccount.signals
 import django.db.models.signals
 from django.dispatch import receiver
 
@@ -9,3 +10,26 @@ from marketplace.models.user import User, UserType
 def create_volunteer_profile(instance, created, raw, **_kwargs):
     if created and not raw and instance.initial_type == UserType.VOLUNTEER:
         marketplace.user.volunteer.ensure_profile(instance)
+
+
+@receiver(allauth.socialaccount.signals.pre_social_login)
+def process_social_login(request, sociallogin, **_kwargs):
+    user = sociallogin.user
+
+    # Set username #
+    if user.email and not user.username:
+        # Set reasonable username
+        # (socialaccount does not base this on email address)
+        #
+        # TODO: handle collisions?
+        # socialaccount does, but then you get that lame username.
+        user.username = user.email.split('@', 1)[0]
+
+    # Assign requested user type (pre-OAuth) #
+    user_type = request.session.pop('oauth_signup_usertype', None)
+
+    if not sociallogin.is_existing:
+        if user_type == 'volunteer':
+            user.initial_type = UserType.VOLUNTEER
+        elif user_type == 'organization':
+            user.initial_type = UserType.ORGANIZATION

--- a/src/marketplace/signals.py
+++ b/src/marketplace/signals.py
@@ -1,0 +1,11 @@
+import django.db.models.signals
+from django.dispatch import receiver
+
+from marketplace.domain import marketplace
+from marketplace.models.user import User, UserType
+
+
+@receiver(django.db.models.signals.post_save, sender=User)
+def create_volunteer_profile(instance, created, raw, **_kwargs):
+    if created and not raw and instance.initial_type == UserType.VOLUNTEER:
+        marketplace.user.volunteer.ensure_profile(instance)

--- a/src/marketplace/socialprovider_urls.py
+++ b/src/marketplace/socialprovider_urls.py
@@ -1,0 +1,31 @@
+from importlib import import_module
+
+from allauth.socialaccount import providers
+
+
+# Note: This is not the documented manner of installing allauth paths.
+# Rather, for example, you might:
+#
+#     path('accounts/', include('allauth.urls')),
+#
+# (And you certainly don't need a separate urls module for that purpose.)
+#
+# However, that installs all of allauth's account-handling controllers.
+# For now, we only need OAuth provider URLs.
+#
+# So instead, we use this module to cleanly define just the provider paths,
+# and then include these as needed.
+#
+# https://django-allauth.readthedocs.io/en/latest/installation.html
+
+
+urlpatterns = []
+
+for provider in providers.registry.get_list():
+    try:
+        prov_mod = import_module(provider.get_package() + '.urls')
+    except ImportError:
+        pass
+    else:
+        prov_urlpatterns = getattr(prov_mod, 'urlpatterns', ())
+        urlpatterns.extend(prov_urlpatterns)

--- a/src/marketplace/templates/marketplace/components/signup_provider_list.html
+++ b/src/marketplace/templates/marketplace/components/signup_provider_list.html
@@ -1,0 +1,17 @@
+{% load socialaccount %}
+
+{% get_providers as socialaccount_providers %}
+
+<form id="signup_oauth">
+{% csrf_token %}
+{% for provider in socialaccount_providers %}
+    <button
+        title="Sign up via {{provider.name}}"
+        class="btn {{provider.id}}"
+        type="submit"
+        form="signup_oauth"
+        formaction="{% url 'marketplace:signup_oauth' user_type provider.id %}"
+        formmethod="post"
+    >{{provider.name}}</button>
+{% endfor %}
+</form>

--- a/src/marketplace/templates/marketplace/signup.html
+++ b/src/marketplace/templates/marketplace/signup.html
@@ -7,9 +7,15 @@
   {% endif %}
 
   <div class="col-lg-12">
-    <form id="signup">
-      <h2 class="section-header">Sign up</h2>
+    <h2 class="section-header">Sign up</h2>
 
+    <p>Sign up and log in via one of these providers or by filling out the form below.</p>
+
+    {% include "marketplace/components/signup_provider_list.html" with user_type=user_type %}
+
+    <hr>
+
+    <form id="signup">
       {% csrf_token %}
       {% include 'marketplace/components/standard_form_fields.html' with wide_field_names=True %}
 

--- a/src/marketplace/tests/domain/common.py
+++ b/src/marketplace/tests/domain/common.py
@@ -12,12 +12,14 @@ def example_organization_user(
     email='orguser@example.com',
     first_name="Organization",
     last_name="User",
+    **kwargs
 ):
     return User(
         username=username,
         email=email,
         first_name=first_name,
         last_name=last_name,
+        **kwargs
     )
 
 
@@ -26,12 +28,14 @@ def example_staff_user(
     email='staffuser@example.com',
     first_name="Staff",
     last_name="User",
+    **kwargs
 ):
     return User(
         username=username,
         email=email,
         first_name=first_name,
         last_name=last_name,
+        **kwargs
     )
 
 
@@ -40,12 +44,14 @@ def example_volunteer_user(
     email="volunteer@email.com",
     first_name="Volunteer",
     last_name="User",
+    **kwargs
 ):
     return User(
         username=username,
         email=email,
         first_name=first_name,
         last_name=last_name,
+        **kwargs
     )
 
 

--- a/src/marketplace/tests/domain/common.py
+++ b/src/marketplace/tests/domain/common.py
@@ -1,35 +1,53 @@
 from django.utils import timezone
 from django.core.exceptions import PermissionDenied
 
-from marketplace.models.common import ReviewStatus, SocialCause
+from marketplace.models.common import SocialCause
 from marketplace.models.user import User
 from marketplace.models.proj import Project
 from marketplace.models.org import Organization, Budget, YearsInOperation, GeographicalScope
 
 
-def example_organization_user():
-    organization_user = User()
-    organization_user.username = "OrgUser"
-    organization_user.first_name = "Organization"
-    organization_user.last_name = "User"
-    organization_user.email = "orguser@email.com"
-    return organization_user
+def example_organization_user(
+    username="OrgUser",
+    email='orguser@example.com',
+    first_name="Organization",
+    last_name="User",
+):
+    return User(
+        username=username,
+        email=email,
+        first_name=first_name,
+        last_name=last_name,
+    )
 
-def example_staff_user():
-    staff_user = User()
-    staff_user.username = "StaffUser"
-    staff_user.first_name = "Staff"
-    staff_user.last_name = "User"
-    staff_user.email = "staffuser@email.com"
-    return staff_user
 
-def example_volunteer_user(username="VolUser", email="volunteer@email.com"):
-    volunteer_user = User()
-    volunteer_user.username = username
-    volunteer_user.first_name = "Volunteer"
-    volunteer_user.last_name = "User"
-    volunteer_user.email = email
-    return volunteer_user
+def example_staff_user(
+    username="StaffUser",
+    email='staffuser@example.com',
+    first_name="Staff",
+    last_name="User",
+):
+    return User(
+        username=username,
+        email=email,
+        first_name=first_name,
+        last_name=last_name,
+    )
+
+
+def example_volunteer_user(
+    username="VolUser",
+    email="volunteer@email.com",
+    first_name="Volunteer",
+    last_name="User",
+):
+    return User(
+        username=username,
+        email=email,
+        first_name=first_name,
+        last_name=last_name,
+    )
+
 
 def example_organization():
     organization = Organization()

--- a/src/marketplace/tests/domain/test_proj.py
+++ b/src/marketplace/tests/domain/test_proj.py
@@ -5,7 +5,6 @@ from django.contrib.auth.models import AnonymousUser
 from marketplace.domain import marketplace
 from marketplace.domain.org import OrganizationService
 from marketplace.domain.proj import ProjectService, ProjectTaskService
-from marketplace.domain.user import UserService
 
 from marketplace.models.common import ReviewStatus, SkillLevel, Score, TaskType
 from marketplace.models.proj import (
@@ -49,27 +48,34 @@ class ProjectTestCase(TestCase):
         self.volunteer_user = example_volunteer_user()
         self.volunteer_user.special_code = "AUTOMATICVOLUNTEER"
         marketplace.user.add_user(self.volunteer_user, 'volunteer')
-        UserService.create_volunteer_profile(self.volunteer_user, self.volunteer_user.id)
 
-        self.volunteer_applicant_user = example_volunteer_user(username="applicant", email="applicant@email.com")
-        self.volunteer_applicant_user.special_code = "AUTOMATICVOLUNTEER"
+        self.volunteer_applicant_user = example_volunteer_user(
+            username="applicant",
+            email='applicant-volunteer@example.com',
+            special_code="AUTOMATICVOLUNTEER",
+        )
         marketplace.user.add_user(self.volunteer_applicant_user, 'volunteer')
-        UserService.create_volunteer_profile(self.volunteer_applicant_user, self.volunteer_applicant_user.id)
 
-        self.scoping_user = example_volunteer_user(username="scopinguser", email="scoping@email.com")
-        self.scoping_user.special_code = "AUTOMATICVOLUNTEER"
+        self.scoping_user = example_volunteer_user(
+            username="scopinguser",
+            email='scopinguser@example.com',
+            special_code="AUTOMATICVOLUNTEER",
+        )
         marketplace.user.add_user(self.scoping_user, 'volunteer')
-        UserService.create_volunteer_profile(self.scoping_user, self.scoping_user.id)
 
-        self.proj_mgmt_user = example_volunteer_user(username="managementuser", email="management@email.com")
-        self.proj_mgmt_user.special_code = "AUTOMATICVOLUNTEER"
+        self.proj_mgmt_user = example_volunteer_user(
+            username="managementuser",
+            email='managementuser@example.com',
+            special_code="AUTOMATICVOLUNTEER",
+        )
         marketplace.user.add_user(self.proj_mgmt_user, 'volunteer')
-        UserService.create_volunteer_profile(self.proj_mgmt_user, self.proj_mgmt_user.id)
 
-        self.qa_user = example_volunteer_user(username="qauser", email="qa@email.com")
-        self.qa_user.special_code = "AUTOMATICVOLUNTEER"
+        self.qa_user = example_volunteer_user(
+            username="qauser",
+            email="qa@email.com",
+            special_code="AUTOMATICVOLUNTEER",
+        )
         marketplace.user.add_user(self.qa_user, 'volunteer')
-        UserService.create_volunteer_profile(self.qa_user, self.qa_user.id)
 
         self.organization = example_organization()
         OrganizationService.create_organization(self.owner_user, self.organization)

--- a/src/marketplace/tests/domain/test_user.py
+++ b/src/marketplace/tests/domain/test_user.py
@@ -62,11 +62,12 @@ class UserTestCase(TestCase):
         self.dssg_staff_user = dssg_user
 
     def test_organization_user(self):
-        organization_user = User()
-        organization_user.username = "OrgUser"
-        organization_user.first_name = "Organization"
-        organization_user.last_name = "User"
-        organization_user.email = "org@email.com"
+        organization_user = User(
+            username="OrgUser",
+            email='orguser@example.com',
+            first_name="Organization",
+            last_name="User",
+        )
         marketplace.user.add_user(organization_user, 'organization')
         self.assertEqual(UserService.get_user(organization_user, organization_user.id), organization_user)
 
@@ -81,31 +82,12 @@ class UserTestCase(TestCase):
         self.assertEqual(UserService.get_user(organization_user, organization_user.id), organization_user)
 
     def test_dssg_user(self):
-        dssg_user = User()
-        dssg_user.username = "DSSGUser"
-        dssg_user.first_name = "DSSG"
-        dssg_user.last_name = "Staff"
-        dssg_user.special_code = "MAKEDSSG"
-        dssg_user.email = "dssg@email.com"
-        marketplace.user.add_user(dssg_user, 'organization')
-        self.assertEqual(UserService.get_user(dssg_user, dssg_user.id), dssg_user)
-
-        self.assertTrue(UserService.user_is_dssg_staff(dssg_user, dssg_user))
-        self.assertFalse(UserService.user_is_organization_creator(dssg_user))
-        self.assertFalse(UserService.user_has_skills(dssg_user))
-        self.assertFalse(UserService.user_has_volunteer_profile(dssg_user))
-        self.assertFalse(UserService.user_has_approved_volunteer_profile(dssg_user))
-
-        UserService.create_volunteer_profile(dssg_user, volunteer_user.id)
-        self.assertTrue(UserService.user_has_volunteer_profile(dssg_user))
-        self.assertFalse(UserService.user_has_approved_volunteer_profile(dssg_user))
-
-    def test_dssg_user(self):
-        volunteer_user = User()
-        volunteer_user.username = "VolUser"
-        volunteer_user.first_name = "Volunteer"
-        volunteer_user.last_name = "User"
-        volunteer_user.email = "volunteer@email.com"
+        volunteer_user = User(
+            username="VolUser",
+            first_name="Volunteer",
+            last_name="User",
+            email="volunteer@email.com",
+        )
         marketplace.user.add_user(volunteer_user, 'volunteer')
 
         self.assertFalse(UserService.user_is_dssg_staff(volunteer_user, volunteer_user))
@@ -120,9 +102,10 @@ class UserTestCase(TestCase):
         self.assertTrue(volunteer_user.volunteerprofile.is_edited)
         self.assertFalse(UserService.user_has_approved_volunteer_profile(volunteer_user))
 
-        self.assertEqual(set(UserService.get_pending_volunteer_profiles(self.dssg_staff_user)),
-            set([volunteer_user.volunteerprofile]))
-
+        self.assertSequenceEqual(
+            marketplace.user.query_pending_volunteer_profiles(self.dssg_staff_user),
+            [volunteer_user.volunteerprofile],
+        )
 
         UserService.accept_volunteer_profile(self.dssg_staff_user, volunteer_user.volunteerprofile.id)
         self.assertTrue(volunteer_user.volunteerprofile.is_edited)

--- a/src/marketplace/urls.py
+++ b/src/marketplace/urls.py
@@ -3,7 +3,10 @@ from django.urls import path, reverse_lazy
 
 from .views import common, org, proj, user, admin
 
+
+# Set URL namespace
 app_name = 'marketplace'
+
 urlpatterns = [
     path('', user.home_view, name='home'),
     path('about/', common.about_view, name='about'),
@@ -65,14 +68,16 @@ urlpatterns = [
     path('proj/<int:proj_pk>/staff/<int:role_pk>/remove', proj.project_role_delete_view, name='proj_staff_remove'),
     path('proj/<int:proj_pk>/volunteers', proj.project_volunteers_view, name='proj_volunteers'),
 
-
     path('logout/', user.logout_view, name='logout'),
     path('login/', auth_views.LoginView.as_view(template_name='marketplace/login.html'), name='login'),
+
     path('signup/select', user.select_user_type_view, name='signup_type_select'),
     path('signup/do/<str:user_type>', user.signup, name='signup_form'),
+
     path('user/pwdchange', auth_views.PasswordChangeView.as_view(template_name='marketplace/user_pwd_change.html',
                                                                  success_url=reverse_lazy('marketplace:my_user_profile'),
                                                                  extra_context={'breadcrumb':user.change_password_breadcrumb()}),name='user_pwd_change'),
+
     path('pwd/resetrequest', auth_views.PasswordResetView.as_view(template_name='marketplace/pwd_reset_request.html',
                                                                  success_url=reverse_lazy('marketplace:pwd_reset_request_done'),
                                                                  email_template_name='marketplace/password_reset_email.html',
@@ -81,7 +86,6 @@ urlpatterns = [
     path('pwd/reset/<str:uidb64>/<str:token>', auth_views.PasswordResetConfirmView.as_view(template_name='marketplace/pwd_reset.html',
                                                                                             success_url=reverse_lazy('marketplace:pwd_reset_complete')), name='pwd_reset'),
     path('pwd/reset/done', auth_views.PasswordResetCompleteView.as_view(template_name='marketplace/pwd_reset_complete.html'), name='pwd_reset_complete'),
-
 
     path('volunteers/', user.volunteer_list_view, name='volunteer_list'),
     path('user/', user.my_user_profile_view, name='my_user_profile'),
@@ -98,5 +102,4 @@ urlpatterns = [
 
     path('ajax/org/<int:org_pk>/candidates/', org.get_all_users_not_organization_members_json, name='validate_username'),
     path('ajax/org/<int:org_pk>/candidates/<str:query>', org.get_all_users_not_organization_members_json, name='validate_username_do'),
-
 ]

--- a/src/marketplace/urls.py
+++ b/src/marketplace/urls.py
@@ -73,6 +73,7 @@ urlpatterns = [
 
     path('signup/select', user.select_user_type_view, name='signup_type_select'),
     path('signup/do/<str:user_type>', user.signup, name='signup_form'),
+    path('signup/do/<str:user_type>/via/<str:provider_id>/', user.signup_oauth, name='signup_oauth'),
 
     path('user/pwdchange', auth_views.PasswordChangeView.as_view(template_name='marketplace/user_pwd_change.html',
                                                                  success_url=reverse_lazy('marketplace:my_user_profile'),

--- a/src/marketplace/views/admin.py
+++ b/src/marketplace/views/admin.py
@@ -12,6 +12,7 @@ from rules.contrib.views import (
 from ..models.user import VolunteerProfile
 from .common import build_breadcrumb, home_link, paginate
 
+from marketplace.domain import marketplace
 from marketplace.domain.user import UserService
 
 
@@ -29,7 +30,7 @@ class AdminHomeView(PermissionRequiredMixin, generic.ListView):
     allow_empty = True
 
     def get_queryset(self):
-        return UserService.get_pending_volunteer_profiles(self.request.user)
+        return marketplace.user.query_pending_volunteer_profiles(self.request.user)
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)

--- a/src/marketplace/views/user.py
+++ b/src/marketplace/views/user.py
@@ -10,6 +10,7 @@ from django.http import Http404, HttpResponseRedirect
 from django.shortcuts import get_object_or_404, redirect, render
 from django.urls import reverse, reverse_lazy
 from django.views import generic
+from django.views.decorators.http import require_http_methods, require_POST
 from django.views.generic.edit import CreateView, DeleteView, UpdateView
 from django.conf import settings
 from rules.contrib.views import (
@@ -285,7 +286,7 @@ def user_preferences_edit_view(request, user_pk):
     userprofile = get_object_or_404(User, pk=user_pk)
     if request.method == 'POST':
         try:
-            UserService.save_user_task_preferences(userprofile, userprofile, request.POST.getlist('preferences'))
+            marketplace.user.set_task_preferences(userprofile, request.POST.getlist('preferences'))
             return redirect('marketplace:user_profile', user_pk=user_pk)
         except KeyError:
             raise Http404
@@ -334,17 +335,12 @@ def user_profile_skills_edit_view(request, user_pk):
                         })
 
 
+@require_POST
 @permission_required('user.is_same_user', raise_exception=True, fn=objectgetter(User, 'user_pk'))
 def create_volunteer_profile_view(request, user_pk):
-    if request.method == 'GET':
-        raise Http404
-    elif request.method == 'POST':
-        try:
-            volunteer_profile = UserService.create_volunteer_profile(request.user, user_pk)
-            return redirect('marketplace:user_volunteer_profile_edit', user_pk=user_pk, volunteer_pk=volunteer_profile.id)
-        except KeyError:
-            messages.error(request, 'There was an error while processing your request.')
-            return redirect('marketplace:user_profile', user_pk=user_pk)
+    volunteer_profile = marketplace.user.volunteer.ensure_profile(request.user)
+    return redirect('marketplace:user_volunteer_profile_edit',
+                    user_pk=user_pk, volunteer_pk=volunteer_profile.pk)
 
 
 def select_user_type_view(request):
@@ -371,7 +367,8 @@ class SignUpForm(UserCreationForm):
         )
 
 
-def signup(request, user_type=None):
+@require_http_methods(['GET', 'POST'])
+def signup(request, user_type):
     if user_type not in ('volunteer', 'organization'):
         raise Http404
 
@@ -380,14 +377,17 @@ def signup(request, user_type=None):
         preferences = request.POST.getlist('preferences')
 
         if form.is_valid():
-            new_user = form.save(commit=False)
             try:
                 if not marketplace.user.verify_captcha(
                     request.POST.get('g-recaptcha-response')
                 ):
                     raise ValueError('Incorrect reCAPTCHA answer')
 
-                marketplace.user.add_user(new_user, user_type, preferences)  # also ValueError
+                marketplace.user.add_user(
+                    form.save(commit=False),
+                    user_type,
+                    preferences,
+                )  # also ValueError
             except ValueError as exc:
                 form.add_error(None, str(exc))
             else:

--- a/src/project/settings.py
+++ b/src/project/settings.py
@@ -20,7 +20,9 @@ from django.core.exceptions import ImproperlyConfigured
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
-SITE_NAME=config('SITE_NAME', default='DSSG Solve')
+SITE_ID = 1
+
+SITE_NAME = config('SITE_NAME', default='DSSG Solve')
 
 # Quick-start development settings - unsuitable for production
 # See https://docs.djangoproject.com/en/2.0/howto/deployment/checklist/
@@ -61,17 +63,37 @@ if file_storage_option not in file_storage_options:
 # Application definition
 
 INSTALLED_APPS = [
-    'django_countries',
+    # our apps
     'marketplace.apps.MarketplaceConfig',
+
+    # social login
+    'allauth',
+    'allauth.account',
+    'allauth.socialaccount',
+    # ...enabled providers
+	# 'allauth.socialaccount.providers.bitbucket',
+    # 'allauth.socialaccount.providers.bitbucket_oauth2',
+    # 'allauth.socialaccount.providers.facebook',
+    'allauth.socialaccount.providers.github',
+    # 'allauth.socialaccount.providers.gitlab',
+    'allauth.socialaccount.providers.google',
+    # 'allauth.socialaccount.providers.linkedin',
+    # 'allauth.socialaccount.providers.linkedin_oauth2',
+
+    # third-party apps
+    'django_countries',
+    'rules',
+    'markdown_deux',
+    'widget_tweaks',
+
+    # django apps
     'django.contrib.admin',
     'django.contrib.auth',
     'django.contrib.contenttypes',
-    'django.contrib.sessions',
     'django.contrib.messages',
+    'django.contrib.sessions',
+    'django.contrib.sites',
     'django.contrib.staticfiles',
-    'rules',
-    'widget_tweaks',
-    'markdown_deux',
 ]
 
 if file_storage_option == 's3':
@@ -146,6 +168,7 @@ AUTH_PASSWORD_VALIDATORS = [
 
 AUTHENTICATION_BACKENDS = (
     'rules.permissions.ObjectPermissionBackend',
+    'allauth.account.auth_backends.AuthenticationBackend',
     'django.contrib.auth.backends.ModelBackend',
 )
 
@@ -154,6 +177,9 @@ AUTH_USER_MODEL = 'marketplace.User'
 LOGIN_REDIRECT_URL = 'marketplace:home'
 
 LOGIN_URL = 'marketplace:login'
+
+# allauth
+ACCOUNT_EMAIL_REQUIRED = True
 
 # Internationalization
 # https://docs.djangoproject.com/en/2.0/topics/i18n/

--- a/src/project/urls.py
+++ b/src/project/urls.py
@@ -12,6 +12,7 @@ Class-based views
 Including another URLconf
     1. Import the include() function: from django.urls import include, path
     2. Add a URL to urlpatterns:  path('blog/', include('blog.urls'))
+
 """
 from django.contrib import admin
 from django.urls import include, path
@@ -21,6 +22,9 @@ from django.views.static import serve
 
 urlpatterns = [
     path('', include('marketplace.urls')),
+
+    path('accounts/', include('marketplace.socialprovider_urls')),
+
     path('admin/', admin.site.urls),
 
     url(r'^media/(?P<path>.*)$', serve, {


### PR DESCRIPTION
Integration with django-allauth for OAuth sign-up

Beginning with Google & GitHub

(Handling for OAuth simple log-in flow – including non-signed-up accounts – still to do.)

OAuth providers don't have a stable concept of a "username" and so that
has to be supplied. allauth doesn't assume you're collecting email
address (or something ...?) and so by default it creates a bizarre username
for you. Previously when I've used it, I didn't bother with a username
field at all. But for this, I've inserted a signal receiver which sets a
reasonable username, from the email address, immediately after the user
returns from the OAuth provider, but before their record has been saved.

And because in the sign-up flow the user selects their account type
first, (and perhaps regardless), the nicest thing for the user, and
simply the most pragmatic thing for us, was to store this selection in
their session, if and only if they request to sign up via OAuth.
(I dislike this overall but it's generally how these sorts of redirects
through OAuth are handled.) In the same signal receiver, we can
thereby set their `User.initial_type` appropriately, (once they have a
User, and before that field value is needed).

A general post-save signal receiver can then appropriately ensure the
user's volunteer profile, once the user's record has been saved.

