### PR TITLE
prompt user to agree to legal docs before signing up

### DIFF
--- a/src/marketplace/static/css/dssgsolve.css
+++ b/src/marketplace/static/css/dssgsolve.css
@@ -43,6 +43,9 @@ body {
 .section-header {
   margin-top: 25px;
 }
+.section-header-primary {
+  margin-top: 10px;
+}
 
 .main-page-container {
   padding-top: 50px;
@@ -418,4 +421,32 @@ fieldset legend {
     color: transparent;
  *
  */
+}
+
+.btn-affirm {
+	color: #fff;
+	background-color: #95a5a6;
+	border-color: #95a5a6;
+}
+.btn-affirm:hover {
+	background-color: #809395;
+	border-color: #798d8f;
+}
+.btn-affirm.focus {
+  box-shadow: none;
+  -webkit-box-shadow: none;
+}
+.btn-affirm.active {
+  background-color: #80a415;
+  border-color: #80a415;
+}
+
+.btn-affirm .post-affirm {
+	display: none;
+}
+.btn-affirm.active .post-affirm {
+	display: block;
+}
+.btn-affirm.active .pre-affirm {
+	display: none;
 }

--- a/src/marketplace/templates/marketplace/components/signup_provider_list.html
+++ b/src/marketplace/templates/marketplace/components/signup_provider_list.html
@@ -3,20 +3,26 @@
 {% get_providers as socialaccount_providers %}
 
 <form id="signup_oauth">
+  <fieldset
+      {% if form_disabled %}disabled="disabled"{% endif %}
+  >
+
 {% csrf_token %}
 
 {% for preference in preferences %}
-  <input type="hidden" name="preferences" value="{{ preference }}">
+    <input type="hidden" name="preferences" value="{{ preference }}">
 {% endfor %}
 
 {% for provider in socialaccount_providers %}
-    <button
-        title="Sign up via {{provider.name}}"
-        class="btn btn-outline-light provider {{provider.id}}"
-        type="submit"
-        form="signup_oauth"
-        formaction="{% url 'marketplace:signup_oauth' user_type provider.id %}"
-        formmethod="post"
-    ><i class="fab fa-{{provider.id}}"></i>{{provider.name}}</button>
+      <button
+          title="Sign up via {{provider.name}}"
+          class="btn btn-outline-light provider {{provider.id}}"
+          type="submit"
+          form="signup_oauth"
+          formaction="{% url 'marketplace:signup_oauth' user_type provider.id %}"
+          formmethod="post"
+      ><i class="fab fa-{{provider.id}}"></i>{{provider.name}}</button>
 {% endfor %}
+
+  </fieldset>
 </form>

--- a/src/marketplace/templates/marketplace/signup.html
+++ b/src/marketplace/templates/marketplace/signup.html
@@ -7,15 +7,45 @@
   {% endif %}
 
   <div class="col-lg-12">
-    <h2 class="section-header">Sign up</h2>
 
-    <p>Sign up and log in via one of these providers or by filling out the form below.</p>
+    <div class="row">
+      <div class="col-md-9 col-lg-7 col-xl-6">
+        <h4 class="section-header-primary">Review our Terms of Use and Privacy Policy</h4>
 
-    {% include "marketplace/components/signup_provider_list.html" %}
+        <div class="row">
+          <div class="col-sm-8">
+            <p>
+              First, please affirm your agreement with Solve for Good's
+              <a href="{% url 'marketplace:terms' %}">Terms of Use</a> and
+              <a href="{% url 'marketplace:privacy' %}">Privacy Policy</a>.
+            </p>
+          </div>
+          <div class="col-sm-4">
+            <div class="btn-group-toggle pt-sm-1">
+              <label id="legal_agreement" class="btn btn-affirm">
+                <input type="checkbox" autocomplete="off"> I agree
+                <i class="material-icons on-right pre-affirm">check_box_outline_blank</i>
+                <i class="material-icons on-right post-affirm">check_box</i>
+              </label>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <hr>
+
+    <h4 class="section-header">Sign up</h4>
+
+    <p>Now, sign up and log in via one of these providers or by filling out the form below.</p>
+
+    {% include "marketplace/components/signup_provider_list.html" with form_disabled=True %}
 
     <hr>
 
     <form id="signup">
+      <fieldset disabled="disabled">
+
       {% csrf_token %}
       {% include 'marketplace/components/standard_form_fields.html' with wide_field_names=True %}
 
@@ -71,8 +101,59 @@
         </div>
       </div>
 
+      </fieldset>
     </form>
+
   </div>
 
+  <script>
+    $(
+      function () {
+        /* Disallow sign-up without legal agreement.
+         *
+         * Sign-up form fieldsets are disabled unless user has agreed to legal terms.
+         *
+         * To prevent a race condition, additionally reproduces the `.active` class logic of
+         * Boostrap's `data-toggle="buttons"`, (against which other logic, e.g. CSS, is based).
+         */
+        'use strict';
+
+        var
+            // our targets
+            agreementBtn = $('#legal_agreement'),
+            signUpForms = $('#signup, #signup_oauth'),
+
+            // our handlers
+            syncActive = function () {
+              /* Set class `active` in sync with whether underlying form field is checked.
+               */
+              var $this = $(this),
+                  isActive = $this.find('input').is(':checked');
+
+              $this.toggleClass('active', isActive);
+            },
+            allowSignUp = function (agreementBtn, signUpForms) {
+              /* Disable sign-up form fieldsets unless legal agreement button is activated.
+               */
+              var agreed = agreementBtn.hasClass('active'),
+                  fieldsets = signUpForms.find('fieldset');
+
+              fieldsets.attr('disabled', agreed ? null : 'disabled');
+            },
+            syncAll = function () {
+              /* All of the above
+               */
+              syncActive.call(this);
+              allowSignUp(agreementBtn, signUpForms);
+            };
+
+        // Sync each time agreement button is clicked
+        agreementBtn.click(syncAll);
+
+        // ...And once on initialization to be sure
+        syncAll.call(agreementBtn);
+      }
+    );
+  </script>
 
 {% endblock %}

--- a/src/marketplace/views/user.py
+++ b/src/marketplace/views/user.py
@@ -434,7 +434,7 @@ def create_volunteer_profile_view(request, user_pk):
 
 def select_user_type_before(request):
     return render(request, 'marketplace/signup_type_select.html', {
-        'breadcrumb': [home_link(), ('Select your account type', None)],
+        'breadcrumb': [home_link(), ('Get started', None)],
     })
 
 
@@ -604,7 +604,7 @@ def signup(request, user_type):
     return render(request, 'marketplace/signup.html', {
         'form': form,
         'user_type': user_type,
-        'breadcrumb': build_breadcrumb([home_link(), ('Sign up', None)]),
+        'breadcrumb': build_breadcrumb([home_link(), ('Get started', reverse('marketplace:signup_type_select')), ('Sign up', None)]),
         'captcha_site_key': settings.RECAPTCHA_SITE_KEY,
         'preferences': preferences,
     })


### PR DESCRIPTION
links to terms & privacy pages are inserted into top of sign-up page,
along with "I agree" button. all other form controls are disabled so
long as button is not activated.

breadcrumb for sign-up is also corrected to reflect that sign-up page is
(optionally) a second step, following user type selection page, (now
labeled "Get started").

resolves #32