### PR TITLE
automated/continuous deployment

### DIFF
--- a/.github/workflows/build-deploy.yml
+++ b/.github/workflows/build-deploy.yml
@@ -1,0 +1,24 @@
+name: CI/CD
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  staging:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: '3.x'
+          
+      - name: Install management dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirement/console.txt
+
+      - name: Build, push & deploy
+        run: manage --show build staging --label=${{ github.ref }} --if-latest --login --push --deploy

--- a/manage.py
+++ b/manage.py
@@ -298,9 +298,12 @@ class DeploymentMixin:
         # https://docs.github.com/en/rest/reference/repos#deployments
         # https://developer.github.com/v3/previews/#deployment-statuses
         # NOTE: required for "in_progress" status -- application/vnd.github.flash-preview+json
-        # NOTE: if necessary of course can accept multiples!
+        # session.headers.update({'Accept': 'application/vnd.github+json'})
         # session.headers.update({'Accept': 'application/vnd.github.v3+json'})
+        # session.headers.update({'Accept': 'application/vnd.github.ant-man-preview+json'})
         session.headers.update({'Accept': 'application/vnd.github.flash-preview+json'})
+        # session.headers.update({'Accept': 'application/vnd.github.v3+json, '
+        #                                   'application/vnd.github.flash-preview+json'})
         return session
 
     def check_latest(self):


### PR DESCRIPTION
CLI flags & integration of existing build/deploy command scripting with the Github Deployment API for record, guardrails and automation; basic outline of a Github Action to leverage this script to deploy tagged releases to staging.

(This Action will require further configuration, elsewhere, namely secrets; but, hopefully, the below workflow will do the trick. Production to be added once this is tested against staging.)